### PR TITLE
feat: optimize replication information retrieval scope for improved performance

### DIFF
--- a/main.go
+++ b/main.go
@@ -203,6 +203,7 @@ const (
 
 type query struct {
 	baseDN       string
+	scope        int
 	searchFilter string
 	searchAttr   string
 	metric       *prometheus.GaugeVec
@@ -277,12 +278,14 @@ var (
 	queries = []*query{
 		{
 			baseDN:       baseDN,
+			scope:        ldap.ScopeWholeSubtree,
 			searchFilter: objectClass(monitoredObject),
 			searchAttr:   monitoredInfo,
 			metric:       monitoredObjectGauge,
 			setData:      setValue,
 		}, {
 			baseDN:       baseDN,
+			scope:        ldap.ScopeWholeSubtree,
 			searchFilter: objectClass(monitorCounterObject),
 			searchAttr:   monitorCounter,
 			metric:       monitorCounterObjectGauge,
@@ -290,6 +293,7 @@ var (
 		},
 		{
 			baseDN:       opsBaseDN,
+			scope:        ldap.ScopeWholeSubtree,
 			searchFilter: objectClass(monitorOperation),
 			searchAttr:   monitorOpCompleted,
 			metric:       monitorOperationGauge,
@@ -297,6 +301,7 @@ var (
 		},
 		{
 			baseDN:       opsBaseDN,
+			scope:        ldap.ScopeWholeSubtree,
 			searchFilter: objectClass(monitorOperation),
 			searchAttr:   monitorOpCompleted,
 			metric:       monitorOperationGauge,
@@ -376,6 +381,7 @@ func (s *Scraper) addReplicationQueries() {
 		queries = append(queries,
 			&query{
 				baseDN:       s.Sync,
+				scope:        ldap.ScopeBaseObject,
 				searchFilter: "(contextCSN=*)",
 				searchAttr:   monitorReplicationFilter,
 				metric:       monitorReplicationGauge,
@@ -498,7 +504,7 @@ func (s *Scraper) scrapeReplication() []ReplicaStatus {
 		}
 
 		req := ldap.NewSearchRequest(
-			s.Sync, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+			s.Sync, ldap.ScopeBaseObject, ldap.NeverDerefAliases, 0, 0, false,
 			"(contextCSN=*)", []string{monitorReplicationFilter}, nil,
 		)
 		sr, err := replica.Search(req)
@@ -549,7 +555,7 @@ func (s *Scraper) scrapeReplication() []ReplicaStatus {
 
 func scrapeQuery(conn *ldap.Conn, q *query) error {
 	req := ldap.NewSearchRequest(
-		q.baseDN, ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		q.baseDN, q.scope, ldap.NeverDerefAliases, 0, 0, false,
 		q.searchFilter, []string{q.searchAttr}, nil,
 	)
 	sr, err := conn.Search(req)


### PR DESCRIPTION
Currently, `sub` scope was used for replication information, which fetched all entries under the base DN. I changed it to `base` to retrieve information only from the base DN itself. This change improves performance by limiting the scope of the query.

In my case, it took `0m0.069s` for the search using `sub` scope.

```
$ time ldapsearch -x -h ldap.example.com -D "cn=manager,dc=example,dc=com" -W -b "dc=example,dc=com" -s sub  "contextCSN=*" contextCSN
# extended LDIF
#
# LDAPv3
# base <dc=example,dc=com> with scope baseObject
# filter: contextCSN=*
# requesting: contextCSN
#

# example.com
dn: dc=example,dc=com,
contextCSN: 20241227004734.408350Z#000000#000#000000

# search result
search: 2
result: 0 Success

# numResponses: 2
# numEntries: 1

real    0m0.069s
user    0m0.005s
sys     0m0.000s
```

It took `0m0.006s` for the search using `base` scope.

```
$ time ldapsearch -x -h ldap.example.com -D "cn=manager,dc=example,dc=com" -W -b "dc=example,dc=com" -s base  "contextCSN=*" contextCSN
# extended LDIF
#
# LDAPv3
# base <dc=example,dc=com> with scope baseObject
# filter: contextCSN=*
# requesting: contextCSN
#

# example.com
dn: dc=example,dc=com,
contextCSN: 20241227004734.408350Z#000000#000#000000

# search result
search: 2
result: 0 Success

# numResponses: 2
# numEntries: 1

real    0m0.006s
user    0m0.005s
sys     0m0.000s
```
