### PR TITLE
fix: the default ldap-addr value was invalid

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 		},
 		&cli.StringFlag{
 			Name:    ldapAddr,
-			Value:   "localhost:389",
+			Value:   "ldap://localhost:389",
 			Usage:   "Address and port of OpenLDAP server",
 			Sources: cli.NewValueSourceChain(yaml.YAML(ldapAddr, sourcer), cli.EnvVar("LDAP_ADDR")),
 		},


### PR DESCRIPTION
When starting the exporter without any parameters it fails to scrap the openldap server with messages like:

```
2025/09/29 09:49:58 ERROR dial failed component=scraper
```

Setting the URL scheme makes it work as expected.